### PR TITLE
Fix x64 Darwin build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,25 +16,25 @@ jobs:
           - darwin
           - linux
           - win32
+        arch:
+          - x64
+          - arm64
         include:
           - name: darwin
-            os: macos-14
-            arch: arm64
-            arch2: none
-          - name: darwin
-            os: macos-13
             arch: x64
-            arch2: none
+            os: macos-13
+          - name: darwin
+            arch: arm64
+            os: macos-14
           - name: linux
             os: ubuntu-latest
-            arch: x64
-            # node-gyp --arch=arm64 still produced x64 binaries.
-            # Maybe use https://buildjet.com/for-github-actions/docs/about/pricing#arm?
-            arch2: none
           - name: win32
             os: windows-latest
-            arch: x64
-            arch2: arm64
+        exclude:
+          # node-gyp --arch=arm64 still produced x64 binaries.
+          # Maybe use https://buildjet.com/for-github-actions/docs/about/pricing#arm?
+          - name: linux
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -43,15 +43,9 @@ jobs:
           node-version: 20
           cache: yarn
 
-      # Build main arch and run tests.
+      # Build and run tests.
       - run: yarn install --frozen-lockfile
       - run: yarn test
-
-      # Build secondary arch.
-      - run: npx node-gyp rebuild --arch=${{ matrix.arch2 }}
-        if: ${{ matrix.arch2 != 'none' }}
-      - run: node scripts/build-sub-package.js ${{ matrix.arch2 }}
-        if: ${{ matrix.arch2 != 'none' }}
 
       # Upload artifacts.
       - name: Upload node-pty-${{ matrix.name }}-${{ matrix.arch }}
@@ -60,10 +54,3 @@ jobs:
           name: node-pty-${{ matrix.name }}-${{ matrix.arch }}
           path: node_modules/@lydell/node-pty-${{ matrix.name }}-${{ matrix.arch }}
           if-no-files-found: error
-      - name: Upload node-pty-${{ matrix.name }}-${{ matrix.arch2 }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: node-pty-${{ matrix.name }}-${{ matrix.arch2 }}
-          path: node_modules/@lydell/node-pty-${{ matrix.name }}-${{ matrix.arch2 }}
-          if-no-files-found: error
-        if: ${{ matrix.arch2 != 'none' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           # Maybe use https://buildjet.com/for-github-actions/docs/about/pricing#arm?
           - name: linux
             arch: arm64
+          # We'll build this with x64. There is need for a separate job.
+          - name: win32
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +49,12 @@ jobs:
       # Build and run tests.
       - run: yarn install --frozen-lockfile
       - run: yarn test
+
+      # Build arm64 for Windows.
+      - run: npx node-gyp rebuild --arch=${{ matrix.arch }}
+        if: ${{ matrix.name == 'win32' && matrix.arch != 'arm64' }}
+      - run: node scripts/build-sub-package.js ${{ matrix.arch }}
+        if: ${{ matrix.name == 'win32' && matrix.arch != 'arm64' }}
 
       # Upload artifacts.
       - name: Upload node-pty-${{ matrix.name }}-${{ matrix.arch }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 build/
 dist/
 artifacts/

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,7 +11,7 @@ const variants = [
   {
     platform: "darwin",
     arch: "x64",
-    tested: false,
+    tested: true,
   },
   {
     platform: "darwin",


### PR DESCRIPTION
This PR fixes the issue with the x64 Darwin build where it would segfault (see https://github.com/lydell/run-pty/issues/61) when running any command. This was due to the previous x64 binary being built on the `macos-14`, which it can't do as it runs on Apple Silicon.

Changes:
- Modifies the strategy matrix from 1x3 (`name`) to 2x3 (`name` and `arch`)
- Excludes the job to build arm64 on Linux
- Excludes the job to build arm64 on Windows (this is done in the x64 windows job)
- Runs the secondary arch build only for arm64 on Windows
- Drops `arch2` keys